### PR TITLE
Build only from actual tags

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -2,8 +2,6 @@ name: Image
 on:
   pull_request:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -22,7 +20,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=edge,branch=main
+            type=sha,format=long
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -51,18 +49,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Run Trivy vulnerability scanner
-        if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ steps.meta.outputs.tags }}
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -1,0 +1,29 @@
+name: Scheduled security scan
+on:
+  schedule:
+    - cron: '0 2 * * 1-5'
+
+jobs:
+  build:
+    name: Trivy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      # Let Trivy pull the image based on the SHA to make sure we’re scanning the image that is “out in the field” rather than something we build locally for each scan.
+      # 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/k0sproject/pushgateway-ttl:sha-${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          # Disable to scan all vulnerabilities. If it would be annoying, we can set the severity level.
+          #severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,8 +1,6 @@
-name: Security scan
+name: Security scan for PRs
 on:
   pull_request:
-  schedule:
-    - cron: '0 2 * * 1-5'
 
 jobs:
   build:
@@ -11,9 +9,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      # We need to build single arch image because docker cannot export multiarch images from buildx currently
+      # and thus we cannot use the image workflows images for scanning
       - name: Build an image from Dockerfile
         run: |
           docker build -t quay.io/k0sproject/pushgateway-ttl:${{ github.sha }} .
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
Building and re-tagging `edge` causes problems in quay.io as it very aggressively cleans up SHAs which have no tag on them.

Also changed the scheduled trivy scan to pull the SHA tag instead of building the image.

The general idea I had for these changes:
- build and scan the image for each PR in a single workflow
- push tags only on github tags
    - push also a SHA tag so we can reference it later in scheduled scans
- the scheduled scan pulls the corresponding SHA tag to make sure we're scanning the image that is "out in the field" rather than something we build locally for each scan.